### PR TITLE
Fix syntax errors in bazel zipper patch

### DIFF
--- a/recipe/0004-zipper-from-conda-package.patch
+++ b/recipe/0004-zipper-from-conda-package.patch
@@ -68,5 +68,4 @@ index c2dd86e..0afd4f7 100755
 +    srcs = [":zipper-exec"],
 +)
 -- 
-2.35.1
-
+2.35.0

--- a/recipe/0004-zipper-from-conda-package.patch
+++ b/recipe/0004-zipper-from-conda-package.patch
@@ -63,10 +63,10 @@ index c2dd86e..0afd4f7 100755
 +    visibility = ["//visibility:public"],
  )
 +
-+ filegroup(
-+     name = "zipper",
++filegroup(
++    name = "zipper",
 +    srcs = [":zipper-exec"],
-+ )
++)
 -- 
 2.35.0
 

--- a/recipe/0004-zipper-from-conda-package.patch
+++ b/recipe/0004-zipper-from-conda-package.patch
@@ -68,5 +68,5 @@ index c2dd86e..0afd4f7 100755
 +    srcs = [":zipper-exec"],
 +)
 -- 
-2.35.0
+2.35.1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - 0008-win-Disable-VS-activation-and-make-build-verbose.patch
 
 build:
-  number: 2
+  number: 3
   ignore_prefix_files: true
   binary_relocation: false
 


### PR DESCRIPTION
The indentation is incorrect, which causes builds requiring zipper to fail.

Fixes #121