### PR TITLE
Allow openjdk 17 again

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - sed                      # [unix]
-    - openjdk >=8,<17          # [unix]
+    - openjdk >=8              # [unix]
     # we need $BUILD_PREFIX/bin/{grpc_cpp_plugin,grpc_java_plugin,protoc}
     - grpc_java_plugin         # [unix]
     - libgrpc                  # [unix]
@@ -49,10 +49,10 @@ requirements:
     - libabseil        # [unix]
     - libgrpc          # [unix]
     - libprotobuf      # [unix]
-    - openjdk >=8,<17  # [win]
+    - openjdk >=8      # [win]
     - posix            # [win]
   run:
-    - openjdk >=8,<17
+    - openjdk >=8
     - posix                    # [win]
     - ijar {{ version }}       # [build_platform != target_platform]
     - singlejar {{ version }}  # [build_platform != target_platform]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
     - patches/0009-Update-windows-VS-detection-code-to-account-for-new-.patch
 
 build:
-  number: 1
+  number: 2
   ignore_prefix_files: true
   binary_relocation: false
 


### PR DESCRIPTION
After incompatibilities were found with the (at-the-time) new openjdk 17 and bazel <5.2 (see #136), we added https://github.com/conda-forge/bazel-feedstock/commit/3a43b0e129c8a6ab11f19de1a8e92e540ef48c6f.

Now that it's way more widespread, let's see if we can re-enable that again.