### PR TITLE
[6.x] Rebuild for libgrpc 1.63 & libprotobuf 5.26.1

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,9 +5,9 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.12'
+- '2.17'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
@@ -21,9 +21,9 @@ docker_image:
 libabseil:
 - '20240116'
 libgrpc:
-- '1.62'
+- '1.63'
 libprotobuf:
-- 4.25.3
+- 5.26.1
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -25,9 +25,9 @@ docker_image:
 libabseil:
 - '20240116'
 libgrpc:
-- '1.62'
+- '1.63'
 libprotobuf:
-- 4.25.3
+- 5.26.1
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -21,9 +21,9 @@ docker_image:
 libabseil:
 - '20240116'
 libgrpc:
-- '1.62'
+- '1.63'
 libprotobuf:
-- 4.25.3
+- 5.26.1
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/migrations/libgrpc163_libprotobuf5261.yaml
+++ b/.ci_support/migrations/libgrpc163_libprotobuf5261.yaml
@@ -1,0 +1,11 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libgrp 1.63 & libprotobuf 5.26.1
+  kind: version
+  paused: true
+  migration_number: 2
+libgrpc:
+- "1.63"
+libprotobuf:
+- 5.26.1
+migrator_ts: 1711628174.9404116

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -21,9 +21,9 @@ cxx_compiler_version:
 libabseil:
 - '20240116'
 libgrpc:
-- '1.62'
+- '1.63'
 libprotobuf:
-- 4.25.3
+- 5.26.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -21,9 +21,9 @@ cxx_compiler_version:
 libabseil:
 - '20240116'
 libgrpc:
-- '1.62'
+- '1.63'
 libprotobuf:
-- 4.25.3
+- 5.26.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -71,7 +71,6 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
-
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,7 +22,7 @@ fi
 # The protobuf-java needs to be manually bumped if necessary
 # See https://protobuf.dev/support/version-support/
 export PROTOC_VERSION=$(conda list -p $PREFIX libprotobuf | grep -v '^#' | tr -s ' ' | cut -f 2 -d ' ' | sed -E 's/^[0-9]+\.([0-9]+\.[0-9]+)$/\1/')
-export PROTOBUF_JAVA_MAJOR_VERSION="3"
+export PROTOBUF_JAVA_MAJOR_VERSION="4"
 export BAZEL_BUILD_OPTS="--crosstool_top=//bazel_toolchain:toolchain --define=PROTOBUF_INCLUDE_PATH=${PREFIX}/include --cpu=${TARGET_CPU} --cxxopt=-std=c++17"
 if [[ "${target_platform}" != "linux-ppc64le" ]]; then
   # linux-ppc64le is only correctly supported in newer bazel versions

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ source:
     - patches/0012-Use-old-sytle-condition-for-linux64.patch
 
 build:
-  number: 0
+  number: 1
   ignore_prefix_files: true
   binary_relocation: false
 


### PR DESCRIPTION
To unblock `protobuf`, which now needs bazel