### PR TITLE
Only pass `--batch` to bazel on Macs

### DIFF
--- a/recipe/bazel-wrapper.sh
+++ b/recipe/bazel-wrapper.sh
@@ -15,11 +15,14 @@ PREFIX_DIR=$(dirname ${PREFIX_DIR})
 
 # FIXME: Since migrating to gRPC 1.78.0, we are seeing spurious hangs with
 # the client/server setup on macOS. Remove again if those are gone.
-if [[ "$*" = *"--version"* ]]; then
-  $PREFIX_DIR/bin/bazel-real --batch $*
-elif [[ "$*" != *"--output_user_root"* ]]; then
-  $PREFIX_DIR/bin/bazel-real --batch --output_user_root ${PREFIX_DIR}/share/bazel $*
-else
-  $PREFIX_DIR/bin/bazel-real --batch $*
+if [[ $(uname) == "Darwin" ]]; then
+  BATCH_ARG="--batch"
 fi
 
+if [[ "$*" = *"--version"* ]]; then
+  $PREFIX_DIR/bin/bazel-real ${BATCH_ARG} $*
+elif [[ "$*" != *"--output_user_root"* ]]; then
+  $PREFIX_DIR/bin/bazel-real ${BATCH_ARG} --output_user_root ${PREFIX_DIR}/share/bazel $*
+else
+  $PREFIX_DIR/bin/bazel-real ${BATCH_ARG} $*
+fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -56,7 +56,8 @@ fi
 export PROTOC=$BUILD_PREFIX/bin/protoc
 export GRPC_JAVA_PLUGIN=$BUILD_PREFIX/bin/grpc_java_plugin
 export ABSEIL_VERSION=$(conda list -p $PREFIX libabseil --fields version | grep -v '#')
-export GRPC_VERSION=$(conda list -p $PREFIX libgrpc --fields version | grep -v '#')
+# grpc-java often does not have matching `X.Y.1` versions; use `X.Y.0` always
+export GRPC_VERSION=$(conda list -p $PREFIX libgrpc --fields version | grep -v '#' | tr -s ' ' | cut -f 2 -d ' ' | sed -E 's/^([0-9]+\.[0-9]+)\.[0-9]+$/\1.0/')
 export PROTOC_VERSION=$(conda list -p $PREFIX libprotobuf | grep -v '^#' | tr -s ' ' | cut -f 2 -d ' ' | sed -E 's/^[0-9]+\.([0-9]+\.[0-9]+)$/\1/')
 export PROTOBUF_JAVA_MAJOR_VERSION="4"
 export BAZEL_BUILD_OPTS="--crosstool_top=//bazel_toolchain:toolchain --define=PROTOBUF_INCLUDE_PATH=${PREFIX}/include --cpu=${TARGET_CPU} --cxxopt=-std=c++17"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
     sha256: 463faee497df2913854d80776784137cb47f42960b4ef4e4f85068c8da4849a8  # [win]
 
 build:
-  number: 1
+  number: 2
   ignore_prefix_files: true
   binary_relocation: false
   # We are currently unable to select a JDK toolchain for the build.


### PR DESCRIPTION
Containing the workaround to just the problematic platform.

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.